### PR TITLE
fix: TracedScore performance improvement

### DIFF
--- a/src/dtypes.js
+++ b/src/dtypes.js
@@ -4,11 +4,12 @@ const directions = Object.freeze({
     LEFT: 2,
     TOP: 3,
 });
+const directionValues = Object.values(directions);
 
 // Data type for traced back, scoring matrix, cel scores.
 // Stores a score value and a traceback direction.
 const TracedScore = (score, direction = directions.NONE) => {
-    if (Object.values(directions).includes(direction)) {
+    if (directionValues.includes(direction)) {
         return { score, direction };
     }
     throw TypeError('Invalid direction value for TracedScore');


### PR DESCRIPTION
In our usage of this library, we found performance was pretty slow on larger strings (a few hundred characters).

I did a profile and found a quick win. Object.values(directions) was being called potentially thousands of times in a single test, when the values could instead just be computed once and then used later.

In our tests, this took execution times from 1.5s down to 200ms.